### PR TITLE
Protostream integration on Vert.x CacheManager 

### DIFF
--- a/clustered-embedding-stores/backend/build.gradle
+++ b/clustered-embedding-stores/backend/build.gradle
@@ -8,7 +8,7 @@ group = 'cynicdog.io'
 version = '1.0-SNAPSHOT'
 
 ext {
-    vertxVersion = '4.0.0'
+    vertxVersion = '4.5.11'
 }
 
 java {

--- a/clustered-embedding-stores/backend/build.gradle
+++ b/clustered-embedding-stores/backend/build.gradle
@@ -31,6 +31,9 @@ dependencies {
     implementation 'org.infinispan.protostream:protostream:5.0.12.Final'
 
     // https://mvnrepository.com/artifact/org.infinispan.protostream/protostream-processor
+    implementation 'org.infinispan.protostream:protostream-processor:5.0.5.Final'
+
+    // https://mvnrepository.com/artifact/org.infinispan.protostream/protostream-processor
     annotationProcessor 'org.infinispan.protostream:protostream-processor:5.0.5.Final'
 
     testImplementation 'org.infinispan:infinispan-commons:15.0.0.Final'

--- a/clustered-embedding-stores/backend/build.gradle
+++ b/clustered-embedding-stores/backend/build.gradle
@@ -13,7 +13,7 @@ ext {
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(20)
+        languageVersion = JavaLanguageVersion.of(20) // You can keep Java version as needed
     }
 }
 
@@ -26,6 +26,12 @@ dependencies {
     implementation("io.vertx:vertx-web-client:${vertxVersion}")
     implementation("io.vertx:vertx-infinispan:${vertxVersion}")
     implementation("io.vertx:vertx-health-check:${vertxVersion}")
+
+    // https://mvnrepository.com/artifact/org.infinispan.protostream/protostream
+    implementation 'org.infinispan.protostream:protostream:5.0.12.Final'
+
+    // https://mvnrepository.com/artifact/org.infinispan.protostream/protostream-processor
+    annotationProcessor 'org.infinispan.protostream:protostream-processor:5.0.5.Final'
 
     testImplementation 'org.infinispan:infinispan-commons:15.0.0.Final'
     testImplementation platform('org.junit:junit-bom:5.10.0')

--- a/clustered-embedding-stores/backend/src/main/java/cynicdog/io/Main.java
+++ b/clustered-embedding-stores/backend/src/main/java/cynicdog/io/Main.java
@@ -11,9 +11,7 @@ import io.vertx.ext.cluster.infinispan.InfinispanClusterManager;
 import io.vertx.ext.healthchecks.HealthCheckHandler;
 import io.vertx.ext.healthchecks.HealthChecks;
 import io.vertx.ext.web.Router;
-import org.infinispan.commons.api.CacheContainerAdmin;
 import org.infinispan.commons.dataconversion.MediaType;
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.Configuration;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
@@ -67,7 +65,7 @@ public class Main extends AbstractVerticle {
                 new GlobalConfigurationBuilder()
                         .transport()
                         .defaultTransport()
-//                        .addProperty("configurationFile", "default-configs/default-jgroups-kubernetes.xml")
+                        .serialization()
                         .build()
         );
 
@@ -82,7 +80,7 @@ public class Main extends AbstractVerticle {
         // Configure the cache for embeddings
         Configuration cacheConfig = new ConfigurationBuilder().clustering()
                 .cacheMode(CacheMode.REPL_SYNC)
-                .encoding().key().mediaType(MediaType.APPLICATION_PROTOSTREAM_TYPE)
+                .encoding().key().mediaType(MediaType.APPLICATION_OBJECT_TYPE)
                 .encoding().value().mediaType(MediaType.APPLICATION_PROTOSTREAM_TYPE)
                 .build();
 

--- a/clustered-embedding-stores/backend/src/main/java/cynicdog/io/Main.java
+++ b/clustered-embedding-stores/backend/src/main/java/cynicdog/io/Main.java
@@ -48,6 +48,7 @@ public class Main extends AbstractVerticle {
                 .create(vertx)
                 .register("cluster-health", ClusterHealthCheck.createProcedure(vertx, false))));
 
+        // Register EventBus consumers
         registerEventBusConsumer("embed", ollamaAPI::embed);
         registerEventBusConsumer("evict", ollamaAPI::evict);
         registerEventBusConsumer("evictAll", ollamaAPI::evictAll);
@@ -66,10 +67,11 @@ public class Main extends AbstractVerticle {
                 new GlobalConfigurationBuilder()
                         .transport()
                         .defaultTransport()
-                        .serialization()
 //                        .addProperty("configurationFile", "default-configs/default-jgroups-kubernetes.xml")
                         .build()
         );
+
+        // Configure Infinispan caches for Vert.x clustering
         cacheManager.defineConfiguration("distributed-cache", new ConfigurationBuilder().clustering().cacheMode(CacheMode.DIST_SYNC).build());
         cacheManager.defineConfiguration("__vertx.subs", new ConfigurationBuilder().clustering().cacheMode(CacheMode.REPL_SYNC).build());
         cacheManager.defineConfiguration("__vertx.haInfo", new ConfigurationBuilder().clustering().cacheMode(CacheMode.REPL_SYNC).build());

--- a/clustered-embedding-stores/backend/src/main/java/cynicdog/io/api/OllamaAPI.java
+++ b/clustered-embedding-stores/backend/src/main/java/cynicdog/io/api/OllamaAPI.java
@@ -1,5 +1,6 @@
 package cynicdog.io.api;
 
+import cynicdog.io.data.Embedding;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.Vertx;
@@ -225,32 +226,5 @@ public class OllamaAPI {
                 });
 
         return promise.future();
-    }
-
-    public static class Embedding {
-
-        private List<Float> latentScores; // Change to List<Float>
-        private String document;
-
-        public Embedding(List<Float> latentScores, String document) {
-            this.latentScores = latentScores;
-            this.document = document;
-        }
-
-        public List<Float> getLatentScores() {
-            return latentScores;
-        }
-
-        public void setLatentScores(List<Float> latentScores) {
-            this.latentScores = latentScores;
-        }
-
-        public String getDocument() {
-            return document;
-        }
-
-        public void setDocument(String document) {
-            this.document = document;
-        }
     }
 }

--- a/clustered-embedding-stores/backend/src/main/java/cynicdog/io/data/Embedding.java
+++ b/clustered-embedding-stores/backend/src/main/java/cynicdog/io/data/Embedding.java
@@ -1,0 +1,38 @@
+package cynicdog.io.data;
+
+import org.infinispan.protostream.annotations.ProtoFactory;
+import org.infinispan.protostream.annotations.ProtoField;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public  class Embedding {
+
+    @ProtoField(number = 1, collectionImplementation = ArrayList.class)
+    List<Float> latentScores;
+
+    @ProtoField(number = 2)
+    String document;
+
+    @ProtoFactory
+    public Embedding(List<Float> latentScores, String document) {
+        this.latentScores = latentScores;
+        this.document = document;
+    }
+
+    public List<Float> getLatentScores() {
+        return latentScores;
+    }
+
+    public void setLatentScores(List<Float> latentScores) {
+        this.latentScores = latentScores;
+    }
+
+    public String getDocument() {
+        return document;
+    }
+
+    public void setDocument(String document) {
+        this.document = document;
+    }
+}

--- a/clustered-embedding-stores/backend/src/main/java/cynicdog/io/data/EmbeddingSchema.java
+++ b/clustered-embedding-stores/backend/src/main/java/cynicdog/io/data/EmbeddingSchema.java
@@ -6,8 +6,7 @@ import org.infinispan.protostream.annotations.ProtoSchema;
 @ProtoSchema(
         includeClasses = {Embedding.class},
         schemaFileName = "embedding.proto",
-        schemaFilePath = "proto",
-        schemaPackageName = "embedding"
+        schemaFilePath = "proto"
 )
 public interface EmbeddingSchema extends GeneratedSchema {
 }

--- a/clustered-embedding-stores/backend/src/main/java/cynicdog/io/data/EmbeddingSchema.java
+++ b/clustered-embedding-stores/backend/src/main/java/cynicdog/io/data/EmbeddingSchema.java
@@ -1,0 +1,13 @@
+package cynicdog.io.data;
+
+import org.infinispan.protostream.GeneratedSchema;
+import org.infinispan.protostream.annotations.ProtoSchema;
+
+@ProtoSchema(
+        includeClasses = {Embedding.class},
+        schemaFileName = "embedding.proto",
+        schemaFilePath = "proto",
+        schemaPackageName = "embedding"
+)
+public interface EmbeddingSchema extends GeneratedSchema {
+}

--- a/clustered-embedding-stores/backend/src/main/java/cynicdog/io/data/EmbeddingSchema.java
+++ b/clustered-embedding-stores/backend/src/main/java/cynicdog/io/data/EmbeddingSchema.java
@@ -1,9 +1,9 @@
 package cynicdog.io.data;
 
 import org.infinispan.protostream.GeneratedSchema;
-import org.infinispan.protostream.annotations.ProtoSchema;
+import org.infinispan.protostream.annotations.AutoProtoSchemaBuilder;
 
-@ProtoSchema(
+@AutoProtoSchemaBuilder(
         includeClasses = {Embedding.class},
         schemaFileName = "embedding.proto",
         schemaFilePath = "proto"

--- a/clustered-embedding-stores/backend/src/main/java/cynicdog/io/util/VectorUtils.java
+++ b/clustered-embedding-stores/backend/src/main/java/cynicdog/io/util/VectorUtils.java
@@ -1,6 +1,6 @@
 package cynicdog.io.util;
 
-import cynicdog.io.api.OllamaAPI;
+import cynicdog.io.data.Embedding;
 import io.vertx.core.impl.logging.Logger;
 import io.vertx.core.impl.logging.LoggerFactory;
 import org.infinispan.Cache;
@@ -11,7 +11,7 @@ public class VectorUtils {
 
     private final static Logger logger = LoggerFactory.getLogger(VectorUtils.class);
 
-    public static String retrieveRelevantDocument(List<Float> embeddings, Cache<String, OllamaAPI.Embedding> collection) {
+    public static String retrieveRelevantDocument(List<Float> embeddings, Cache<String, Embedding> collection) {
         String closestKey = null;
         double maxSimilarity = -1;
 

--- a/clustered-embedding-stores/backend/src/main/resources/proto/embedding.proto
+++ b/clustered-embedding-stores/backend/src/main/resources/proto/embedding.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package cynicdog.io;
+
+message Embedding {
+  repeated float latentScores = 1;
+  string document = 2;
+}

--- a/clustered-embedding-stores/frontend/build.gradle
+++ b/clustered-embedding-stores/frontend/build.gradle
@@ -8,7 +8,7 @@ group = 'cynicdog.io'
 version = '1.0-SNAPSHOT'
 
 ext {
-    vertxVersion = '4.0.0'
+    vertxVersion = '4.5.11'
 }
 
 java {

--- a/clustered-embedding-stores/frontend/src/main/java/cynicdog/io/Main.java
+++ b/clustered-embedding-stores/frontend/src/main/java/cynicdog/io/Main.java
@@ -13,7 +13,6 @@ import io.vertx.ext.healthchecks.HealthChecks;
 import io.vertx.ext.web.Router;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.handler.BodyHandler;
-import org.infinispan.commons.marshall.JavaSerializationMarshaller;
 import org.infinispan.configuration.cache.CacheMode;
 import org.infinispan.configuration.cache.ConfigurationBuilder;
 import org.infinispan.configuration.global.GlobalConfigurationBuilder;
@@ -55,7 +54,6 @@ public class Main extends AbstractVerticle {
                 new GlobalConfigurationBuilder()
                         .transport()
                         .defaultTransport()
-//                        .addProperty("configurationFile", "default-configs/default-jgroups-kubernetes.xml")
                         .build()
         );
         cacheManager.defineConfiguration("__vertx.subs", new ConfigurationBuilder().clustering().cacheMode(CacheMode.REPL_SYNC).build());


### PR DESCRIPTION
Configure `DefaultCacheManager` so that Vert.x takes ownership of the distributed cache manager. 